### PR TITLE
Changed udev rule match from devname to joystick

### DIFF
--- a/udev/70-gamepads.rules
+++ b/udev/70-gamepads.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="input", ENV{DEVNAME}=="/dev/input/js0", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="gamepad_launcher.service"
+ACTION=="add", SUBSYSTEM=="input", ENV{ID_INPUT_JOYSTICK}=="1", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="gamepad_launcher.service"


### PR DESCRIPTION
This should work on a wider range of systems, since it's not
guaranteed that all would assign /dev/input/js0.

Closes #9 